### PR TITLE
Add support for Observation and simplify isEqual

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "NotSwiftUIState",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/NotSwiftUIState/AnyEquatable.swift
+++ b/Sources/NotSwiftUIState/AnyEquatable.swift
@@ -1,25 +1,9 @@
 // Check if the two values are Equatable and equal
 func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
-    func f<LHS>(lhs: LHS) -> Bool {
-        if let typeInfo = Wrapped<LHS>.self as? AnyEquatable.Type {
-            return typeInfo.isEqual(lhs: lhs, rhs: rhs)
-        }
-        return false
+    guard let lhs = lhs as? any Equatable else { return false }
+    func f<LHS: Equatable>(_ lhs: LHS) -> Bool {
+        guard let rhs = rhs as? LHS else { return false }
+        return lhs == rhs
     }
-    return _openExistential(lhs, do: f)
-}
-
-protocol AnyEquatable {
-    static func isEqual(lhs: Any, rhs: Any) -> Bool
-}
-
-enum Wrapped<T> { }
-
-extension Wrapped: AnyEquatable where T: Equatable {
-    static func isEqual(lhs: Any, rhs: Any) -> Bool {
-        guard let l = lhs as? T, let r = rhs as? T else {
-            return false
-        }
-        return l == r
-    }
+    return f(lhs)
 }

--- a/Tests/NotSwiftUIStateTests/ObservationTests.swift
+++ b/Tests/NotSwiftUIStateTests/ObservationTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import Observation
+@testable import NotSwiftUIState
+
+fileprivate var sampleBodyCount = 0
+fileprivate var nestedBodyCount = 0
+
+@Observable
+fileprivate final class ObservableModel {
+    var counter: Int = 0
+}
+
+final class ObservationTests: XCTestCase {
+    override func setUp() {
+        sampleBodyCount = 0
+        nestedBodyCount = 0
+    }
+    
+    func testSimple() {
+        struct Nested: View {
+            @State var model = ObservableModel()
+            var body: some View {
+                Button("\(model.counter)") {
+                    model.counter += 1
+                }
+            }
+        }
+        
+        struct Sample: View {
+            @State var model = ObservableModel()
+            var body: some View {
+                Button("\(model.counter)") {
+                    model.counter += 1
+                }
+                Nested()
+            }
+        }
+        
+        let s = Sample()
+        let node = Node()
+        s.buildNodeTree(node)
+        var button: Button {
+            node.children[0].children[0].view as! Button
+        }
+        var nestedNode: Node {
+            node.children[0].children[1]
+        }
+        var nestedButton: Button {
+            nestedNode.children[0].view as! Button
+        }
+        XCTAssertEqual(button.title, "0")
+        XCTAssertEqual(nestedButton.title, "0")
+        
+        nestedButton.action()
+        node.rebuildIfNeeded()
+        
+        XCTAssertEqual(button.title, "0")
+        XCTAssertEqual(nestedButton.title, "1")
+        
+        button.action()
+        node.rebuildIfNeeded()
+
+        XCTAssertEqual(button.title, "1")
+        XCTAssertEqual(nestedButton.title, "1")
+    }
+    
+    func testBindings() {
+        struct Nested: View {
+            var model: ObservableModel
+            var body: some View {
+                Button("\(model.counter)") {
+                    model.counter += 1
+                }
+            }
+        }
+        
+        struct Sample: View {
+            @State var model = ObservableModel()
+            var body: some View {
+                Nested(model: model)
+            }
+        }
+        
+        let s = Sample()
+        let node = Node()
+        s.buildNodeTree(node)
+        var nestedNode: Node {
+            node.children[0]
+        }
+        var nestedButton: Button {
+            nestedNode.children[0].view as! Button
+        }
+        XCTAssertEqual(nestedButton.title, "0")
+        
+        nestedButton.action()
+        node.rebuildIfNeeded()
+        
+        XCTAssertEqual(nestedButton.title, "1")
+    }
+
+    func testUnusedBinding() {
+        struct Nested: View {
+            var model: ObservableModel
+            var body: some View {
+                Button("") {
+                    model.counter += 1
+                }
+                .debug { nestedBodyCount += 1 }
+            }
+        }
+        
+        struct Sample: View {
+            @State var model = ObservableModel()
+            var body: some View {
+                Button("\(model.counter)") {}
+                Nested(model: model)
+                    .debug { sampleBodyCount += 1 }
+            }
+        }
+        
+        let s = Sample()
+        let node = Node()
+        s.buildNodeTree(node)
+        var nestedNode: Node {
+            node.children[0].children[1]
+        }
+        var nestedButton: Button {
+            nestedNode.children[0].view as! Button
+        }
+        XCTAssertEqual(sampleBodyCount, 1)
+        XCTAssertEqual(nestedBodyCount, 1)
+
+        nestedButton.action()
+        node.rebuildIfNeeded()
+
+        XCTAssertEqual(sampleBodyCount, 2)
+        XCTAssertEqual(nestedBodyCount, 1)
+
+    }
+}
+


### PR DESCRIPTION
As far as I can tell, this series on SwiftUI State Management wasn't updated to include Swift Observation support. I managed to get a few tests, based on `StateTests`, to pass. I didn't get around to implementing the `Bindable` property wrapper.

I also managed to simplify isEqual implementation using features introduced in Swift 5.7. For reference I also started [discussion about this implementation](https://forums.swift.org/t/comparing-two-any-values-for-equality-is-this-the-simplest-implementation/73816) on Swift forums.

I realize this is an old project for an old episode but thought someone, somewhere might be interested. Thank you so much for the inspiration. Would love an update on this series, @floriankugler and @chriseidhof.